### PR TITLE
[SGC-00] Adding a gazebo config to run vsgraph in simulations with gazebo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,6 +210,7 @@ ament_target_dependencies(${PROJECT_NAME}_lib
   image_transport
   rviz_visual_tools
   situational_graphs_msgs
+  segmenter_ros
 )
 
 # Common source files

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,13 +238,20 @@ function(add_ros2_node target_name cpp_file)
     ${COMMON_SOURCES}
     ${cpp_file}
   )
+
   target_link_libraries(${target_name}
     ${PROJECT_NAME}_lib
   )
+
   ament_target_dependencies(${target_name}
     ${COMMON_DEPENDENCIES}
   )
+
   rosidl_target_interfaces(${target_name} ${PROJECT_NAME} "rosidl_typesupport_cpp")
+
+  set_target_properties(${target_name} PROPERTIES
+    INSTALL_RPATH "\$ORIGIN/.."
+  )
 
   install(TARGETS ${target_name}
     DESTINATION lib/${PROJECT_NAME}
@@ -255,16 +262,44 @@ endfunction()
 add_ros2_node(ros_rgbd          src/ros_rgbd.cc)
 add_ros2_node(ros_rgbd_inertial src/ros_rgbd_inertial.cc)
 
+# libvs_graphs_lib.so must also be able to find libDBoW2.so and libg2o.so
+# in the same install/vs_graphs/lib/ folder.
+set_target_properties(${PROJECT_NAME}_lib PROPERTIES
+  INSTALL_RPATH "\$ORIGIN"
+)
+
 # Install other resources
 install(
   DIRECTORY launch config core/Vocabulary
   DESTINATION share/${PROJECT_NAME}
 )
 
-# Install the library
 install(TARGETS ${PROJECT_NAME}_lib
   DESTINATION lib/${PROJECT_NAME}
 )
+
+# Install the main vs_graphs shared library
+install(TARGETS ${PROJECT_NAME}_lib
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+# Install third-party shared libraries needed at runtime
+install(DIRECTORY
+  ${PROJECT_SOURCE_DIR}/core/Thirdparty/DBoW2/lib/
+  DESTINATION lib
+  FILES_MATCHING PATTERN "libDBoW2.so*"
+)
+
+install(DIRECTORY
+  ${PROJECT_SOURCE_DIR}/core/Thirdparty/g2o/lib/
+  DESTINATION lib
+  FILES_MATCHING PATTERN "libg2o.so*"
+)
+
+ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 
 # Ament package configuration
 ament_package()

--- a/config/RGB-D/SMapper_Gazebo.yaml
+++ b/config/RGB-D/SMapper_Gazebo.yaml
@@ -36,8 +36,8 @@ Camera.RGB: 1
 
 # RGBD Parameters
 RGBD.DepthMapFactor: 1.0
-RGBD.NearThresh: 0.1
-RGBD.FarThresh: 10.0
+RGBD.NearThresh: 0.05
+RGBD.FarThresh: 5.0
 
 # Transformation (IMU to Camera)
 IMU.T_b_c1: !!opencv-matrix
@@ -53,11 +53,11 @@ IMU.T_b_c1: !!opencv-matrix
 IMU.InsertKFsWhenLost: 0
 
 # IMU Noise
-IMU.NoiseGyro: 0.0010273469802412588
-IMU.NoiseAcc: 0.005119536556707974
+IMU.NoiseGyro: 0.0008726646
+IMU.NoiseAcc: 0.0065
 IMU.GyroWalk: 3.8743601798420855e-05
 IMU.AccWalk: 0.0007446449364276494
-IMU.Frequency: 400.0
+IMU.Frequency: 250.0
 
 # Number of ORB Features per Frame
 ORBextractor.nFeatures: 2000

--- a/config/RGB-D/SMapper_Gazebo.yaml
+++ b/config/RGB-D/SMapper_Gazebo.yaml
@@ -1,0 +1,87 @@
+%YAML:1.0
+
+#--------------------------------------------------------------------------------------------
+# Camera Parameters. Adjust them! (RealSense D435i camera - Serial Number: 044322070965)
+# Source: https://github.com/snt-arg/smapper/tree/main/calibration/kalibr/static
+#--------------------------------------------------------------------------------------------
+File.version: "1.0"
+
+Camera.type: "PinHole"
+
+# Rectified Camera Intrinsics
+Camera1.fx: 608.8519897460938
+Camera1.fy: 607.9760131835938
+Camera1.cx: 331.6618347167969
+Camera1.cy: 251.41233825683594
+
+# Distortion Parameters
+Camera1.k1: 0.0
+Camera1.k2: 0.0
+Camera1.p1: 0.0
+Camera1.p2: 0.0
+
+# Stereo
+Stereo.b: 0.0499585
+Stereo.ThDepth: 10.0
+
+# Camera Resolution
+Camera.width: 640
+Camera.height: 480
+
+# Camera FPS
+Camera.fps: 30
+
+# Color order of the images (0: BGR, 1: RGB. It is ignored if images are grayscale)
+Camera.RGB: 1
+
+# RGBD Parameters
+RGBD.DepthMapFactor: 1.0
+RGBD.NearThresh: 0.1
+RGBD.FarThresh: 10.0
+
+# Transformation (IMU to Camera)
+IMU.T_b_c1: !!opencv-matrix
+   rows: 4
+   cols: 4
+   dt: f
+   data: [ -0.014727338818110586, -0.9997505489706886, -0.016791227594876112, 0.039938237003778305,
+          -0.05130052290257775, 0.01752642757563294, -0.9985294590979066, -0.11186067996703218,
+           0.9985746651308847, -0.013844282908206218, -0.05154584357151279, -0.12417107842813298,
+           0.0, 0.0, 0.0, 1.0]
+
+# Number of KFs to insert when IMU is lost
+IMU.InsertKFsWhenLost: 0
+
+# IMU Noise
+IMU.NoiseGyro: 0.0010273469802412588
+IMU.NoiseAcc: 0.005119536556707974
+IMU.GyroWalk: 3.8743601798420855e-05
+IMU.AccWalk: 0.0007446449364276494
+IMU.Frequency: 400.0
+
+# Number of ORB Features per Frame
+ORBextractor.nFeatures: 2000
+
+# ORB Scale Factors in the Scale Pyramid
+ORBextractor.scaleFactor: 1.2
+
+# ORB Levels in the Scale Pyramid
+ORBextractor.nLevels: 8
+
+# ORB Extractor Fast Threshold
+ORBextractor.iniThFAST: 20
+ORBextractor.minThFAST: 5
+
+#--------------------------------------------------------------------------------------------
+# Viewer Parameters
+#--------------------------------------------------------------------------------------------
+Viewer.KeyFrameSize: 0.05
+Viewer.KeyFrameLineWidth: 1.0
+Viewer.GraphLineWidth: 0.9
+Viewer.PointSize: 2.0
+Viewer.CameraSize: 0.08
+Viewer.CameraLineWidth: 3.0
+Viewer.ViewpointX: 0.0
+Viewer.ViewpointY: -0.7
+Viewer.ViewpointZ: -3.5
+Viewer.ViewpointF: 500.0

--- a/core/include/Geometric/Plane.h
+++ b/core/include/Geometric/Plane.h
@@ -2,133 +2,368 @@
  * This file is part of Visual S-Graphs (vS-Graphs).
  * Copyright (C) 2023-2025 SnT, University of Luxembourg
  *
- * 📝 Authors: Ali Tourani, Saad Ejaz, Hriday Bavle, Jose Luis Sanchez-Lopez, and Holger Voos
+ * 📝 Authors:  Ali Tourani, Saad Ejaz, Hriday Bavle, Jose Luis Sanchez-Lopez,
+ *              and Holger Voos
  *
- * vS-Graphs is free software: you can redistribute it and/or modify it under the terms
- * of the GNU General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or (at your option) any later version.
+ * vS-Graphs is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
  *
- * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details: https://www.gnu.org/licenses/
-*/
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details: https://www.gnu.org/licenses/
+ */
 
 #ifndef PLANE_H
 #define PLANE_H
 
-#include <set>
 #include "Map.h"
 #include "MapPoint.h"
 #include "Semantic/Marker.h"
-#include "Types/SystemParams.h"
 #include "Thirdparty/g2o/g2o/types/plane3d.h"
+#include "Types/SystemParams.h"
+#include <set>
 
-#include <pcl/common/io.h>
-#include <pcl/common/centroid.h>
-#include <pcl/octree/octree_search.h>
 #include <boost/shared_ptr.hpp>
+#include <pcl/common/centroid.h>
+#include <pcl/common/io.h>
+#include <pcl/octree/octree_search.h>
 
 namespace ORB_SLAM3
 {
-    class Map;
-    class Marker;
-    class MapPoint;
+class Map;
+class Marker;
+class MapPoint;
 
-    class Plane
+class Plane
+{
+  public:
+    enum planeVariant
     {
-    public:
-        enum planeVariant
-        {
-            UNDEFINED = -1,
-            WALL = 0,
-            GROUND = 1,
-            WINDOW = 2
-        };
+        /**
+         * @brief       TODO
+         */
+        UNDEFINED = -1,
 
-        struct Observation
-        {
-            g2o::Plane3D localPlane;                        // The plane equation in the local frame
-            Eigen::Matrix4d Gij;                            // The aggregated point cloud measurement for point-plane constraint
-            double confidence;                              // The aggregated confidence of the plane
-            planeVariant semanticType = UNDEFINED;          // The semantic type of the plane
-        };
+        /**
+         * @brief       TODO
+         */
+        WALL = 0,
 
-        // Variables for bundle adjustment
-        KeyFrame *refKeyFrame;             // The first keyframe that observed the plane is the reference keyframe
-        unsigned long int mnBAGlobalForKF; // The reference keyframe ID for the Global BA the plane was part of
-        g2o::Plane3D mPlaneGBA;            // The plane equation in the global map after the Global BA
+        /**
+         * @brief       TODO
+         */
+        GROUND = 1,
 
-    private:
-        int id;                                             // The plane's identifier
-        int opId;                                           // The plane's identifier in the local optimizer
-        int opIdG;                                          // The plane's identifier in the global optimizer
-        bool mbBad;                                         // Marks the plane as bad (if true, the plane will not be used)
-        planeVariant planeType;                             // The plane's semantic type (e.g., wall, ground, etc.)s
-        Eigen::Vector3f centroid;                           // The centroid of the plane
-        std::vector<uint8_t> color;                         // A color devoted for visualization
-        g2o::Plane3D localEquation;                         // The plane equation in the local map
-        g2o::Plane3D globalEquation;                        // The plane equation in the global map
-        std::set<MapPoint *> mapPoints;                     // The unique set of map points lying on the plane
-        std::map<planeVariant, double> semanticVotes;       // The votes for the semantic type of the plane
-        std::map<KeyFrame *, Observation> observations;    // Plane's observations in keyFrames
-        pcl::PointCloud<pcl::PointXYZRGBA>::Ptr planeCloud; // The point cloud of the plane
-        boost::shared_ptr<pcl::octree::OctreePointCloudSearch<pcl::PointXYZRGBA>> octree; // The octree for the plane cloud
-
-    public:
-        Plane();
-        ~Plane();
-
-        int getId() const;
-        void setId(int value);
-
-        int getOpId() const;
-        void setOpId(int value);
-
-        int getOpIdG() const;
-        void setOpIdG(int value);
-
-        bool isBad();
-        void setBad();
-
-        void setColor();
-        std::vector<uint8_t> getColor() const;
-
-        planeVariant getPlaneType();
-        planeVariant getExpectedPlaneType();
-        void setPlaneType(planeVariant newType);
-
-        void setMapPoints(MapPoint *value);
-        std::set<MapPoint *> getMapPoints();
-
-        Eigen::Vector3f getCentroid() const;
-        void setCentroid(const Eigen::Vector3f &value);
-
-        g2o::Plane3D getLocalEquation() const;
-        void setLocalEquation(const g2o::Plane3D &value);
-
-        g2o::Plane3D getGlobalEquation() const;
-        void setGlobalEquation(const g2o::Plane3D &value);
-
-        void addObservation(KeyFrame *pKF, Observation obs);
-        void eraseObservation(KeyFrame *pKF);
-        const std::map<KeyFrame *, Observation> &getObservations() const;
-
-        pcl::PointCloud<pcl::PointXYZRGBA>::Ptr getMapClouds();
-        void setMapClouds(pcl::PointCloud<pcl::PointXYZRGBA>::Ptr value);
-        void replaceMapClouds(pcl::PointCloud<pcl::PointXYZRGBA>::Ptr value);
-        bool isPointinPlaneCloud(const Eigen::Vector3d &point);
-
-        void castWeightedVote(planeVariant semanticType, double voteWeight);
-        void resetPlaneSemantics();
-
-        Map *GetMap();
-        void SetMap(Map *pMap);
-
-    protected:
-        Map *mpMap;
-        std::mutex mMutexMap, mMutexType;
-        mutable std::mutex mMutexFeatures, mMutexPos;
+        /**
+         * @brief       TODO
+         */
+        WINDOW = 2
     };
-}
+
+    /**
+     * @brief       TODO
+     */
+    struct Observation
+    {
+
+        /**
+         * @brief       The plane equation in the local frame
+         */
+        g2o::Plane3D localPlane;
+
+        /**
+         * @brief       The aggregated point cloud measurement for point-plane
+         *              constraint
+         */
+        Eigen::Matrix4d Gij;
+
+        /**
+         * @brief       The aggregated confidence of the plane
+         */
+        double confidence;
+
+        /**
+         * @brief       The semantic type of the plane
+         */
+        planeVariant semanticType = UNDEFINED;
+    };
+
+    /* ---------------------------------------------------------------------- *
+     * Variables for bundle adjustment
+     * ---------------------------------------------------------------------- */
+
+    /**
+     * @brief       The first keyframe that observed the plane is the  reference
+     *              keyframe
+     */
+    KeyFrame *refKeyFrame;
+
+    /**
+     * @brief       The reference keyframe ID for the Global BA the plane was
+     *              part of
+     */
+    unsigned long int mnBAGlobalForKF;
+
+    /**
+     * @brief       The plane equation in the global map after the Global BA
+     */
+    g2o::Plane3D mPlaneGBA;
+
+  private:
+    /**
+     * @brief       The plane's identifier
+     */
+    int id;
+
+    /**
+     * @brief       The plane's identifier in the local optimizer
+     */
+    int opId;
+
+    /**
+     * @brief       The plane's identifier in the global optimizer
+     */
+    int opIdG;
+
+    /**
+     * @brief       Marks the plane as bad (if true, the plane will not be used)
+     */
+    bool mbBad;
+
+    /**
+     * @brief       The plane's semantic type (e.g., wall, ground, etc.)s
+     */
+    planeVariant planeType;
+
+    /**
+     * @brief       The centroid of the plane
+     */
+    Eigen::Vector3f centroid;
+
+    /**
+     * @brief       A color devoted for visualization
+     */
+    std::vector<uint8_t> color;
+
+    /**
+     * @brief       The plane equation in the local map
+     */
+    g2o::Plane3D localEquation;
+
+    /**
+     * @brief       The plane equation in the global map
+     */
+    g2o::Plane3D globalEquation;
+
+    /**
+     * @brief       The unique set of map points lying on the plane
+     */
+    std::set<MapPoint *> mapPoints;
+
+    /**
+     * @brief       The votes for the semantic type of the plane
+     */
+    std::map<planeVariant, double> semanticVotes;
+
+    /**
+     * @brief       Plane's observations in keyFrames
+     */
+    std::map<KeyFrame *, Observation> observations; //
+
+    /**
+     * @brief       The point cloud of the plane
+     */
+    pcl::PointCloud<pcl::PointXYZRGBA>::Ptr planeCloud;
+
+    /**
+     * @brief       The octree for the plane cloud
+     */
+    boost::shared_ptr<pcl::octree::OctreePointCloudSearch<pcl::PointXYZRGBA>>
+        octree;
+
+  public:
+    Plane();
+    ~Plane();
+
+    /**
+     * @brief       TODO
+     */
+    int getId() const;
+
+    /**
+     * @brief       TODO
+     */
+    void setId(int value);
+
+    /**
+     * @brief       TODO
+     */
+    int getOpId() const;
+
+    /**
+     * @brief       TODO
+     */
+    void setOpId(int value);
+
+    /**
+     * @brief       TODO
+     */
+    int getOpIdG() const;
+
+    /**
+     * @brief       TODO
+     */
+    void setOpIdG(int value);
+
+    /**
+     * @brief       TODO
+     */
+    bool isBad();
+
+    /**
+     * @brief       TODO
+     */
+    void setBad();
+
+    /**
+     * @brief       TODO
+     */
+    void setColor();
+
+    /**
+     * @brief       TODO
+     */
+    std::vector<uint8_t> getColor() const;
+
+    /**
+     * @brief       TODO
+     */
+    planeVariant getPlaneType();
+
+    /**
+     * @brief       TODO
+     */
+    planeVariant getExpectedPlaneType();
+
+    /**
+     * @brief       TODO
+     */
+    void setPlaneType(planeVariant newType);
+
+    /**
+     * @brief       TODO
+     */
+    void setMapPoints(MapPoint *value);
+
+    /**
+     * @brief       TODO
+     */
+    std::set<MapPoint *> getMapPoints();
+
+    /**
+     * @brief       TODO
+     */
+    Eigen::Vector3f getCentroid() const;
+
+    /**
+     * @brief       TODO
+     */
+    void setCentroid(const Eigen::Vector3f &value);
+
+    /**
+     * @brief       TODO
+     */
+    g2o::Plane3D getLocalEquation() const;
+
+    /**
+     * @brief       TODO
+     */
+    void setLocalEquation(const g2o::Plane3D &value);
+
+    /**
+     * @brief       TODO
+     */
+    g2o::Plane3D getGlobalEquation() const;
+
+    /**
+     * @brief       TODO
+     */
+    void setGlobalEquation(const g2o::Plane3D &value);
+
+    /**
+     * @brief       TODO
+     */
+    void addObservation(KeyFrame *pKF, Observation obs);
+
+    /**
+     * @brief       TODO
+     */
+    void eraseObservation(KeyFrame *pKF);
+
+    /**
+     * @brief       TODO
+     */
+    const std::map<KeyFrame *, Observation> &getObservations() const;
+
+    /**
+     * @brief       TODO
+     */
+    pcl::PointCloud<pcl::PointXYZRGBA>::Ptr getMapClouds();
+
+    /**
+     * @brief       TODO
+     */
+    void setMapClouds(pcl::PointCloud<pcl::PointXYZRGBA>::Ptr value);
+
+    /**
+     * @brief       TODO
+     */
+    void replaceMapClouds(pcl::PointCloud<pcl::PointXYZRGBA>::Ptr value);
+
+    /**
+     * @brief       TODO
+     */
+    bool isPointinPlaneCloud(const Eigen::Vector3d &point);
+
+    /**
+     * @brief       TODO
+     */
+    void castWeightedVote(planeVariant semanticType, double voteWeight);
+
+    /**
+     * @brief       TODO
+     */
+    void resetPlaneSemantics();
+
+    /**
+     * @brief       TODO
+     */
+    Map *GetMap();
+
+    /**
+     * @brief       TODO
+     */
+    void SetMap(Map *pMap);
+
+  protected:
+    /**
+     * @brief       TODO
+     */
+    Map *mpMap;
+
+    /**
+     * @brief       TODO
+     */
+    std::mutex mMutexMap, mMutexType;
+
+    /**
+     * @brief       TODO
+     */
+    mutable std::mutex mMutexFeatures, mMutexPos;
+};
+} // namespace ORB_SLAM3
 
 #endif

--- a/core/include/SemanticSegmentation.h
+++ b/core/include/SemanticSegmentation.h
@@ -2,95 +2,140 @@
  * This file is part of Visual S-Graphs (vS-Graphs).
  * Copyright (C) 2023-2025 SnT, University of Luxembourg
  *
- * 📝 Authors: Ali Tourani, Saad Ejaz, Hriday Bavle, Jose Luis Sanchez-Lopez, and Holger Voos
+ * 📝 Authors: Ali Tourani, Saad Ejaz, Hriday Bavle, Jose Luis Sanchez-Lopez,
+ * and Holger Voos
  *
- * vS-Graphs is free software: you can redistribute it and/or modify it under the terms
- * of the GNU General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or (at your option) any later version.
+ * vS-Graphs is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
  *
- * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details: https://www.gnu.org/licenses/
-*/
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details: https://www.gnu.org/licenses/
+ */
 
 #ifndef SEMANTICSEG_H
 #define SEMANTICSEG_H
 
 #include "Atlas.h"
-#include "Utils.h"
 #include "GeoSemHelpers.h"
+#include "Utils.h"
 
-#include <unordered_map>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/PCLPointCloud2.h>
 #include <pcl/common/transforms.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <unordered_map>
 
 namespace ORB_SLAM3
 {
-    class Atlas;
+class Atlas;
 
-    class SemanticSegmentation
-    {
-    private:
-        bool mGeoRuns;
-        Atlas *mpAtlas;
-        std::mutex mMutexNewKFs;
-        const uint8_t bytesPerClassProb = 4; // Four bytes per class probability - refer to scene_segment_ros
-        unsigned long int mLastProcessedKeyFrameId = 0;
-        std::list<std::tuple<uint64_t, cv::Mat, pcl::PCLPointCloud2::Ptr>> segmentedImageBuffer;
+class SemanticSegmentation
+{
+  private:
+    bool mGeoRuns;
 
-        // System parameters
-        SystemParams *sysParams;
+    Atlas *mpAtlas;
 
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-        SemanticSegmentation(Atlas *pAtlas);
+    std::mutex mMutexNewKFs;
 
-        // Semantic segmentation frame buffer processing
-        std::list<std::tuple<uint64_t, cv::Mat, pcl::PCLPointCloud2::Ptr>> GetSegmentedFrameBuffer();
-        void AddSegmentedFrameToBuffer(std::tuple<uint64_t, cv::Mat, pcl::PCLPointCloud2::Ptr> *tuple);
+    // Four bytes per class probability - refer to scene_segment_ros
+    const uint8_t bytesPerClassProb = 4;
 
-        /**
-         * @brief Segments the point cloud into class specific point clouds and enriches them with the current keyframe point cloud
-         * @param pclPc2SegPrb the point cloud to be segmented
-         * @param segImgUncertainity the segmentation image uncertainty
-         * @param clsCloudPtrs the class specific point clouds
-         * @param thisKFPointCloud the current keyframe point cloud
-         */
-        void threshSeparatePointCloud(pcl::PCLPointCloud2::Ptr pclPc2SegPrb,
-                                      cv::Mat &segImgUncertainity,
-                                      std::vector<pcl::PointCloud<pcl::PointXYZRGBA>::Ptr> &clsCloudPtrs,
-                                      const pcl::PointCloud<pcl::PointXYZRGB>::Ptr &thisKFPointCloud);
+    unsigned long int mLastProcessedKeyFrameId = 0;
 
-        /**
-         * @brief Gets all planes for each class specific point cloud using RANSAC
-         * @param clsCloudPtrs the class specific point clouds
-         * @param minCloudSize the minimum size of the point cloud to be segmented
-         * @return a vector of vector of point clouds
-         */
-        std::vector<std::vector<std::pair<pcl::PointCloud<pcl::PointXYZRGBA>::Ptr, Eigen::Vector4d>>> getPlanesFromClassClouds(
+    std::list<std::tuple<uint64_t, cv::Mat, pcl::PCLPointCloud2::Ptr>>
+        segmentedImageBuffer;
+
+    // System parameters
+    SystemParams *sysParams;
+
+  public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+    SemanticSegmentation(Atlas *pAtlas);
+
+    // Semantic segmentation frame buffer processing
+    std::list<std::tuple<uint64_t, cv::Mat, pcl::PCLPointCloud2::Ptr>>
+        GetSegmentedFrameBuffer();
+
+    void AddSegmentedFrameToBuffer(
+        std::tuple<uint64_t, cv::Mat, pcl::PCLPointCloud2::Ptr> *tuple);
+
+    /**
+     * @brief       Segments the point cloud into class specific point clouds
+     *              and enriches them with the current keyframe point cloud
+     *
+     * @param       pclPc2SegPrb
+     *              the point cloud to be segmented
+     *
+     * @param       segImgUncertainity
+     *              the segmentation image uncertainty
+     *
+     * @param       clsCloudPtrs
+     *              the class specific point clouds
+     *
+     * @param       thisKFPointCloud
+     *              the current keyframe point cloud
+     */
+    void threshSeparatePointCloud(
+        pcl::PCLPointCloud2::Ptr pclPc2SegPrb,
+        cv::Mat                 &segImgUncertainity,
+        std::vector<pcl::PointCloud<pcl::PointXYZRGBA>::Ptr> &clsCloudPtrs,
+        const pcl::PointCloud<pcl::PointXYZRGB>::Ptr         &thisKFPointCloud);
+
+    /**
+     * @brief       Gets all planes for each class specific point cloud using
+     *              RANSAC
+     *
+     * @param       clsCloudPtrs
+     *              the class specific point clouds
+     *
+     * @param       minCloudSize
+     *              the minimum size of the point cloud to be segmented
+     *
+     * @return      a vector of vector of point clouds
+     */
+    std::vector<std::vector<
+        std::pair<pcl::PointCloud<pcl::PointXYZRGBA>::Ptr, Eigen::Vector4d>>>
+        getPlanesFromClassClouds(
             std::vector<pcl::PointCloud<pcl::PointXYZRGBA>::Ptr> &clsCloudPtrs);
 
-        /**
-         * @brief Adds the planes to the Atlas
-         * @param clsPlanes the planes to be added
-         * @param clsConfs the confidence of the class predictions
-         */
-        void updatePlaneData(KeyFrame *pKF,
-                             std::vector<std::vector<std::pair<pcl::PointCloud<pcl::PointXYZRGBA>::Ptr, Eigen::Vector4d>>> &clsPlanes);
+    /**
+     * @brief       Adds the planes to the Atlas
+     *
+     * @param       clsPlanes
+     *              the planes to be added
+     *
+     * @param       clsConfs
+     *              the confidence of the class predictions
+     */
+    void updatePlaneData(
+        KeyFrame *pKF,
+        std::vector<
+            std::vector<std::pair<pcl::PointCloud<pcl::PointXYZRGBA>::Ptr,
+                                  Eigen::Vector4d>>> &clsPlanes);
 
-        /**
-         * @brief Updates the map plane
-         * @param planeId the plane id
-         * @param clsId the class id
-         * @param confidence the confidence of the class predictions
-         */
-        void updatePlaneSemantics(int planeId, int clsId, double confidence);
+    /**
+     * @brief       Updates the map plane
+     *
+     * @param       planeId
+     *              the plane id
+     *
+     * @param       clsId
+     *              the class id
+     *
+     * @param       confidence
+     *              the confidence of the class predictions
+     */
+    void updatePlaneSemantics(int planeId, int clsId, double confidence);
 
-        // Running the thread
-        void Run();
-    };
-}
+    // Running the thread
+    void Run();
+};
+} // namespace ORB_SLAM3
 
 #endif // SEMANTICSEG_H

--- a/core/include/SemanticsManager.h
+++ b/core/include/SemanticsManager.h
@@ -2,141 +2,181 @@
  * This file is part of Visual S-Graphs (vS-Graphs).
  * Copyright (C) 2023-2025 SnT, University of Luxembourg
  *
- * 📝 Authors: Ali Tourani, Saad Ejaz, Hriday Bavle, Jose Luis Sanchez-Lopez, and Holger Voos
+ * 📝 Authors: Ali Tourani, Saad Ejaz, Hriday Bavle, Jose Luis Sanchez-Lopez,
+ * and Holger Voos
  *
- * vS-Graphs is free software: you can redistribute it and/or modify it under the terms
- * of the GNU General Public License as published by the Free Software Foundation, either
- * version 3 of the License, or (at your option) any later version.
+ * vS-Graphs is free software: you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option) any later
+ * version.
  *
- * This software is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU General Public License for more details: https://www.gnu.org/licenses/
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+ * details: https://www.gnu.org/licenses/
  */
 
 #ifndef SEMANTICSMANAGER_H
 #define SEMANTICSMANAGER_H
 
 #include "Atlas.h"
-#include "Utils.h"
 #include "GeoSemHelpers.h"
+#include "Utils.h"
 
-#include <unordered_map>
-#include <pcl/point_cloud.h>
-#include <pcl/point_types.h>
 #include <pcl/PCLPointCloud2.h>
 #include <pcl/common/transforms.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <unordered_map>
 
 namespace ORB_SLAM3
 {
-    class Atlas;
+class Atlas;
 
-    class SemanticsManager
-    {
-    private:
-        bool mGeoRuns;
-        Atlas *mpAtlas;
-        std::mutex mMutexNewRooms;
-        Eigen::Matrix4f mPlanePoseMat; // The transformation matrix from ground plane to horizontal
-        const uint8_t runInterval = 3; // The main Run() function runs every runInterval seconds
+class SemanticsManager
+{
+  private:
+    bool            mGeoRuns;
+    Atlas          *mpAtlas;
+    std::mutex      mMutexNewRooms;
+    Eigen::Matrix4f mPlanePoseMat; // The transformation matrix from ground
+                                   // plane to horizontal
+    const uint8_t   runInterval =
+        3; // The main Run() function runs every runInterval seconds
 
-        // System parameters
-        SystemParams *sysParams;
+    // System parameters
+    SystemParams *sysParams;
 
-    public:
-        EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-        SemanticsManager(Atlas *pAtlas);
+  public:
+    EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+    SemanticsManager(Atlas *pAtlas);
 
-        /**
-         * @brief Gets the latest skeleton cluster acquired from voxblox
-         */
-        std::vector<std::vector<Eigen::Vector3d>> getLatestSkeletonCluster();
+    /**
+     * @brief       Gets the latest skeleton cluster acquired from voxblox
+     */
+    std::vector<std::vector<Eigen::Vector3d>> getLatestSkeletonCluster();
 
-        /**
-         * @brief Gets the latest detected room candidates from GNN-based room detection
-         */
-        std::vector<ORB_SLAM3::Room *> getLatestGNNRoomCandidates();
+    /**
+     * @brief       Gets the latest detected room candidates from GNN-based room
+     *              detection
+     */
+    std::vector<ORB_SLAM3::Room *> getLatestGNNRoomCandidates();
 
-        /**
-         * @brief Filters the wall planes to remove heavily tilted walls
-         */
-        void filterWallPlanes();
+    /**
+     * @brief       Filters the wall planes to remove heavily tilted walls
+     */
+    void filterWallPlanes();
 
-        /**
-         * @brief Filters the ground plane to remove points that are too far from the plane
-         * @param groundPlane the main ground plane that is the reference
-         */
-        void filterGroundPlanes(Plane *groundPlane);
+    /**
+     * @brief       Filters the ground plane to remove points that are too far
+     *              from the plane
+     *
+     * @param       groundPlane
+     *              The main ground plane that is the reference
+     */
+    void filterGroundPlanes(Plane *groundPlane);
 
-        /**
-         * @brief Transforms the plane equation to the ground reference defined by mPlanePoseMat
-         * @param planeEq the plane equation
-         * @return the transformed plane equation
-         */
-        Eigen::Vector3f transformPlaneEqToGroundReference(const Eigen::Vector4d &planeEq);
+    /**
+     * @brief       Transforms the plane equation to the ground reference
+     *              defined by mPlanePoseMat
+     *
+     * @param       planeEq
+     *              The plane equation
+     *
+     * @return      The transformed plane equation
+     */
+    Eigen::Vector3f
+        transformPlaneEqToGroundReference(const Eigen::Vector4d &planeEq);
 
-        /**
-         * @brief Gets the median height of a ground plane after transformation to referece by mPlanePoseMat
-         * @param groundPlane the ground plane
-         * @return the median height of the ground plane
-         */
-        float computeGroundPlaneHeight(Plane *groundPlane);
+    /**
+     * @brief       Gets the median height of a ground plane after
+     *              transformation to referece by mPlanePoseMat
+     *
+     * @param       groundPlane
+     *              The ground plane
+     *
+     * @return      The median height of the ground plane
+     */
+    float computeGroundPlaneHeight(Plane *groundPlane);
 
-        /**
-         * @brief Computes the transformation matrix from the ground plane to the horizontal (y-inverted)
-         * @param plane the plane
-         * @return the transformation matrix
-         */
-        Eigen::Matrix4f computePlaneToHorizontal(const Plane *plane);
+    /**
+     * @brief       Computes the transformation matrix from the ground plane to
+     *              the horizontal (y-inverted)
+     *
+     * @param       plane
+     *              The plane
+     *
+     * @return      the transformation matrix
+     */
+    Eigen::Matrix4f computePlaneToHorizontal(const Plane *plane);
 
-        /**
-         * @brief Gets the only rectangular room from the facing walls list (if exists, returns true)
-         * @param givenRoom the address of the given room
-         * @param facingWalls the facing walls list
-         * @param perpThreshDeg the perpendicular threshold in degrees
-         */
-        bool getRectangularRoom(std::pair<std::pair<Plane *, Plane *>, std::pair<Plane *, Plane *>> &givenRoom,
-                                const std::vector<std::pair<Plane *, Plane *>> &facingWalls,
-                                double perpThreshDeg = 5.0);
+    /**
+     * @brief       Gets the only rectangular room from the facing walls list
+     *              (if exists, returns true)
+     *
+     * @param       givenRoom
+     *              The address of the given room
+     *
+     * @param       facingWalls
+     *              The facing walls list
+     *
+     * @param       perpThreshDeg
+     *              The perpendicular threshold in degrees
+     */
+    bool getRectangularRoom(
+        std::pair<std::pair<Plane *, Plane *>, std::pair<Plane *, Plane *>>
+                                                       &givenRoom,
+        const std::vector<std::pair<Plane *, Plane *>> &facingWalls,
+        double                                          perpThreshDeg = 5.0);
 
-        /**
-         * @brief Checks for the existing of a room with particular walls close to a cluster.
-         * It returns the address of the existing room if found, otherwise returns nullptr.
-         * @param clusterCentroid the centroid of the cluster
-         * @param wallList the list of walls to be checked
-         */
-        ORB_SLAM3::Room *associateRooms(const Eigen::Vector3d clusterCentroid,
-            const std::vector<ORB_SLAM3::Plane *> &wallList);
-        
-        /**
-         * @brief Re-associates rooms based on fixed time intervals to avoid duplicates
-         */
-        void reAssociateRooms();
+    /**
+     * @brief       Checks for the existing of a room with particular walls
+     *              close to a cluster. It returns the address of the existing
+     *              room if found, otherwise returns nullptr.
+     *
+     * @param       clusterCentroid
+     *              The centroid of the cluster
+     *
+     * @param       wallList
+     *              The list of walls to be checked
+     */
+    ORB_SLAM3::Room *
+        associateRooms(const Eigen::Vector3d                  clusterCentroid,
+                       const std::vector<ORB_SLAM3::Plane *> &wallList);
 
-        /**
-         * @brief Converts mapped room candidates to rooms using geometric constraints
-         * 🚧 [vS-Graphs v.1.2.0] This solution is not very reliable. It is recommended to use other
-         * structural element recognition solutions.
-         */
-        void updateMapRoomCandidateToRoomGeo(ORB_SLAM3::KeyFrame *pKF);
+    /**
+     * @brief       Re-associates rooms based on fixed time intervals to avoid
+     *              duplicates
+     */
+    void reAssociateRooms();
 
-        /**
-         * @brief Processes the latest skeleton cluster to detect rooms based on free space clustering
-         */
-        void detectRoom_FreeSpaceCluster();
+    /**
+     * @brief       Converts mapped room candidates to rooms using geometric
+     *              constraints 🚧 [vS-Graphs v.1.2.0] This solution is not very
+     *              reliable. It is recommended to use other structural element
+     *              recognition solutions.
+     */
+    void updateMapRoomCandidateToRoomGeo(ORB_SLAM3::KeyFrame *pKF);
 
-        /**
-         * @brief Gets the rooms detected by the GNN module
-         */
-        void detectRoom_GNN();
+    /**
+     * @brief       Processes the latest skeleton cluster to detect rooms based
+     *              on free space clustering
+     */
+    void detectRoom_FreeSpaceCluster();
 
-        /**
-         * @brief Gets the updated floors containing rooms and corridors
-         */
-        void getUpdatedFloors();
+    /**
+     * @brief       Gets the rooms detected by the GNN module
+     */
+    void detectRoom_GNN();
 
-        // Running the thread
-        void Run();
-    };
-}
+    /**
+     * @brief       Gets the updated floors containing rooms and corridors
+     */
+    void getUpdatedFloors();
+
+    // Running the thread
+    void Run();
+};
+} // namespace ORB_SLAM3
 
 #endif // SEMANTICSEG_H

--- a/launch/rgbd-imu.launch.py
+++ b/launch/rgbd-imu.launch.py
@@ -11,43 +11,90 @@ from launch.substitutions import LaunchConfiguration, EqualsSubstitution
 def generate_launch_description():
     return LaunchDescription(
         [
+            # ---------------------------------------------------------------- #
             # Global arguments declarations
-            DeclareLaunchArgument("offline", default_value="true"),
-            DeclareLaunchArgument("launch_rviz", default_value="true"),
-            DeclareLaunchArgument("colored_pointcloud", default_value="true"),
-            DeclareLaunchArgument("visualize_segmented_scene", default_value="true"),
+            # ---------------------------------------------------------------- #
+
+            DeclareLaunchArgument(
+                "offline",
+                default_value="true"
+            ),
+
+            DeclareLaunchArgument(
+                "launch_rviz",
+                default_value="true"
+            ),
+
+            DeclareLaunchArgument(
+                "colored_pointcloud",
+                default_value="true"
+            ),
+
+            DeclareLaunchArgument(
+                "visualize_segmented_scene",
+                default_value="true"
+            ),
+
             DeclareLaunchArgument(
                 "semantic_scene_segmenter",
                 default_value="yoso",
-                description="The method to segment the semantic scene (if off, the baseline)",
-                choices=["yoso", "pfcn", "off"],
+                description=("The method to segment the semantic scene "
+                             "(if off, the baseline)"),
+                choices=[
+                    "yoso",
+                    "pfcn",
+                    "yolo26",
+                    "off"
+                ],
             ),
+
+            # ---------------------------------------------------------------- #
             # Topics
-            DeclareLaunchArgument("camera_frame", default_value="camera"),
-            DeclareLaunchArgument("sensor_config", default_value="SMapper_RealSense"),
+            # ---------------------------------------------------------------- #
+
             DeclareLaunchArgument(
-                "rgb_image_topic", default_value="/camera/realsense/color/image_raw"
+                "camera_frame",
+                default_value="camera"
             ),
+
+            DeclareLaunchArgument(
+                "sensor_config",
+                default_value="SMapper_RealSense"
+            ),
+
+            DeclareLaunchArgument(
+                "rgb_image_topic",
+                default_value="/camera/realsense/color/image_raw"
+            ),
+
             DeclareLaunchArgument(
                 "rgb_camera_info_topic",
                 default_value="/camera/realsense/color/camera_info",
             ),
+
             DeclareLaunchArgument(
                 "depth_image_topic",
                 default_value="/camera/realsense/aligned_depth_to_color/image_raw",
             ),
+
             DeclareLaunchArgument(
                 "imu_topic",
                 default_value="/camera/realsense/imu",
             ),
+
+            # ---------------------------------------------------------------- #
             # VS-Graphs Node
+            # ---------------------------------------------------------------- #
+
             Node(
                 name="vs_graphs",
                 package="vs_graphs",
                 executable="ros_rgbd_inertial",
                 output="screen",
                 parameters=[
-                    {"use_sim_time": LaunchConfiguration("offline")},
+                    {
+                        "use_sim_time": LaunchConfiguration("offline")
+                    },
                     {
                         "voc_file": LaunchConfiguration(
                             "voc_file",
@@ -77,52 +124,124 @@ def generate_launch_description():
                             ],
                         )
                     },
-                    {"yaw": 0.0},
-                    {"roll": 0.0},
-                    {"pitch": 0.0},
-                    {"frame_map": "map"},
-                    {"frame_imu": "imu"},
-                    {"frame_world": "world"},
-                    {"frame_camera": "camera"},
-                    {"enable_pangolin": False},
-                    {"static_transform": True},
-                    {"colored_pointcloud": False},
-                    {"publish_pointclouds": True},
+                    {
+                        "roll": 1.5707963268
+                    },
+                    {
+                        "pitch": 0.0
+                    },
+                    {
+                        "yaw": 0.0
+                    },
+                    {
+                        "frame_map": "map"
+                    },
+                    {
+                        "frame_imu": "imu"
+                    },
+                    {
+                        "frame_world": "world"
+                    },
+                    {
+                        "frame_camera": "camera"
+                    },
+                    {
+                        "enable_pangolin": False
+                    },
+                    {
+                        "static_transform": True
+                    },
+                    {
+                        "colored_pointcloud": False
+                    },
+                    {
+                        "publish_pointclouds": True
+                    },
                 ],
                 remappings=[
-                    ("/imu", LaunchConfiguration("imu_topic")),
-                    ("/camera/rgb/image_raw", LaunchConfiguration("rgb_image_topic")),
+                    (
+                        "/imu",
+                        LaunchConfiguration("imu_topic")
+                    ),
+                    (
+                        "/camera/rgb/image_raw",
+                        LaunchConfiguration("rgb_image_topic")
+                    ),
                     (
                         "/camera/depth_registered/image_raw",
                         LaunchConfiguration("depth_image_topic"),
                     ),
                 ],
             ),
+
+            # ---------------------------------------------------------------- #
             # Static Transforms
+            # ---------------------------------------------------------------- #
+
             Node(
                 package="tf2_ros",
-                name="map_to_map_elevated", # For Voxblox Skeleton
+                name="map_to_map_elevated",  # For Voxblox Skeleton
                 executable="static_transform_publisher",
-                arguments=["0", "0", "0", "0", "0", "0", "map", "map_elevated"],
+                arguments=[
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "map",
+                    "map_elevated"
+                ],
             ),
+
             Node(
                 name="bc_to_se",
                 package="tf2_ros",
                 executable="static_transform_publisher",
-                arguments=["0", "0", "3", "0", "0", "0", "build_comp", "struc_elem"],
+                arguments=[
+                    "0",
+                    "0",
+                    "3",
+                    "0",
+                    "0",
+                    "0",
+                    "build_comp",
+                    "struc_elem"
+                ],
             ),
+
             Node(
                 package="tf2_ros",
                 name="world_to_bc",
                 executable="static_transform_publisher",
-                arguments=["0", "0", "3", "0", "0", "0", "world", "build_comp"],
+                arguments=[
+                    "0",
+                    "0",
+                    "3",
+                    "0",
+                    "0",
+                    "0",
+                    "world",
+                    "build_comp"
+                ],
             ),
+
             Node(
                 package="tf2_ros",
                 name="camera_to_imu",
                 executable="static_transform_publisher",
-                arguments=["0", "0", "0", "1.5708", "0", "1.5708", "camera", "imu"],
+                arguments=[
+                    "0",
+                    "0",
+                    "0",
+                    "1.5708",
+                    "0",
+                    "1.5708",
+                    "camera",
+                    "imu"
+                ],
             ),
+
             Node(
                 package="tf2_ros",
                 name="camera_to_camera_optical",
@@ -139,7 +258,11 @@ def generate_launch_description():
                     # RealSense: camera_color_optical_frame, OpenLoris: d400_color
                 ],
             ),
+
+            # ---------------------------------------------------------------- #
             # RViz
+            # ---------------------------------------------------------------- #
+
             Node(
                 condition=IfCondition(LaunchConfiguration("launch_rviz")),
                 package="rviz2",
@@ -154,7 +277,11 @@ def generate_launch_description():
                 ],
                 output="screen",
             ),
+
+            # ---------------------------------------------------------------- #
             # Nodelete
+            # ---------------------------------------------------------------- #
+
             ComposableNodeContainer(
                 name="depth_image_proc_container",
                 package="rclcpp_components",
@@ -164,7 +291,11 @@ def generate_launch_description():
                     ComposableNode(
                         package="depth_image_proc",
                         name="point_cloud_xyzrgb_node",
-                        parameters=[{"target_frame": "map"}],
+                        parameters=[
+                            {
+                                "target_frame": "map"
+                            }
+                        ],
                         plugin="depth_image_proc::PointCloudXyzrgbNode",
                         remappings=[
                             (
@@ -179,16 +310,21 @@ def generate_launch_description():
                                 "depth_registered/image_rect",
                                 LaunchConfiguration("depth_image_topic"),
                             ),
-                            ("points", "/camera/depth/points"),
+                            (
+                                "points",
+                                "/camera/depth/points"
+                            ),
                         ],
                     ),
                 ],
             ),
+
             # Semantic Scene Segmenter Node (based on semantic_scene_segmenter argument)
             Node(
                 condition=IfCondition(
                     EqualsSubstitution(
-                        LaunchConfiguration("semantic_scene_segmenter"), "yoso"
+                        LaunchConfiguration("semantic_scene_segmenter"),
+                        "yoso"
                     )
                 ),
                 name="segmenter_ros",
@@ -196,8 +332,13 @@ def generate_launch_description():
                 executable="segmenter_yoso.py",
                 output="screen",
                 parameters=[
-                    {"visualize": LaunchConfiguration("visualize_segmented_scene")}
+                    {
+                        "visualize": LaunchConfiguration(
+                            "visualize_segmented_scene"
+                        )
+                    }
                 ],
+
                 arguments=[
                     "--ros-args",
                     "--params-file",
@@ -207,10 +348,14 @@ def generate_launch_description():
                     ],
                 ],
             ),
+
             Node(
                 condition=IfCondition(
                     EqualsSubstitution(
-                        LaunchConfiguration("semantic_scene_segmenter"), "pfcn"
+                        LaunchConfiguration(
+                            "semantic_scene_segmenter"
+                        ),
+                        "pfcn"
                     )
                 ),
                 name="segmenter_ros",
@@ -218,7 +363,11 @@ def generate_launch_description():
                 executable="segmenter_pFCN.py",
                 output="screen",
                 parameters=[
-                    {"visualize": LaunchConfiguration("visualize_segmented_scene")}
+                    {
+                        "visualize": LaunchConfiguration(
+                            "visualize_segmented_scene"
+                        )
+                    }
                 ],
                 arguments=[
                     "--ros-args",
@@ -226,6 +375,36 @@ def generate_launch_description():
                     [
                         get_package_share_directory("segmenter_ros"),
                         "/config/cfg_pFCN.yaml",
+                    ],
+                ],
+            ),
+
+            Node(
+                condition=IfCondition(
+                    EqualsSubstitution(
+                        LaunchConfiguration(
+                            "semantic_scene_segmenter"
+                        ),
+                        "yolo26"
+                    )
+                ),
+                name="segmenter_ros",
+                package="segmenter_ros",
+                executable="segmenter_yolo26.py",
+                output="screen",
+                parameters=[
+                    {
+                        "visualize": LaunchConfiguration(
+                            "visualize_segmented_scene"
+                        )
+                    }
+                ],
+                arguments=[
+                    "--ros-args",
+                    "--params-file",
+                    [
+                        get_package_share_directory("segmenter_ros"),
+                        "/config/cfg_yolo26.yaml",
                     ],
                 ],
             ),

--- a/launch/rgbd.launch.py
+++ b/launch/rgbd.launch.py
@@ -7,42 +7,99 @@ from launch_ros.actions import ComposableNodeContainer
 from ament_index_python.packages import get_package_share_directory
 from launch.substitutions import LaunchConfiguration, EqualsSubstitution
 
+
 def generate_launch_description():
     return LaunchDescription(
         [
+            # ---------------------------------------------------------------- #
             # Global arguments declarations
-            DeclareLaunchArgument("offline", default_value="true"),
-            DeclareLaunchArgument("launch_rviz", default_value="true"),
-            DeclareLaunchArgument("colored_pointcloud", default_value="true"),
-            DeclareLaunchArgument("visualize_segmented_scene", default_value="true"),
+            # ---------------------------------------------------------------- #
+
+            DeclareLaunchArgument(
+                "offline",
+                default_value="true"
+            ),
+
+            DeclareLaunchArgument(
+                "launch_rviz",
+                default_value="true"
+            ),
+
+            DeclareLaunchArgument(
+                "colored_pointcloud",
+                default_value="true"
+            ),
+
+            DeclareLaunchArgument(
+                "visualize_segmented_scene",
+                default_value="true"
+            ),
+
+            DeclareLaunchArgument(
+                "pointcloud_topic",
+                default_value="/camera/depth/points",
+            ),
+
+            DeclareLaunchArgument(
+                "segmented_image_topic",
+                default_value="/camera/color/image_segment",
+            ),
+
             DeclareLaunchArgument(
                 "semantic_scene_segmenter",
                 default_value="yoso",
-                description="The method to segment the semantic scene (if off, the baseline)",
-                choices=["yoso", "pfcn", "off"],
+                description=("The method to segment the semantic scene "
+                             "(if off, the baseline)"),
+                choices=[
+                    "yoso",
+                    "pfcn",
+                    "segformer",
+                    "off"
+                ],
             ),
+
+            # ---------------------------------------------------------------- #
             # Topics
-            DeclareLaunchArgument("camera_frame", default_value="camera"),
-            DeclareLaunchArgument("sensor_config", default_value="SMapper_RealSense"),
+            # ---------------------------------------------------------------- #
+
             DeclareLaunchArgument(
-                "rgb_image_topic", default_value="/camera/realsense/color/image_raw"
+                "camera_frame",
+                default_value="camera"
             ),
+
+            DeclareLaunchArgument(
+                "sensor_config",
+                default_value="SMapper_RealSense"
+            ),
+
+            DeclareLaunchArgument(
+                "rgb_image_topic",
+                default_value="/camera/realsense/color/image_raw"
+            ),
+
             DeclareLaunchArgument(
                 "rgb_camera_info_topic",
                 default_value="/camera/realsense/color/camera_info",
             ),
+
             DeclareLaunchArgument(
                 "depth_image_topic",
                 default_value="/camera/realsense/aligned_depth_to_color/image_raw",
             ),
+
+            # ---------------------------------------------------------------- #
             # VS-Graphs Node
+            # ---------------------------------------------------------------- #
+
             Node(
                 name="vs_graphs",
                 package="vs_graphs",
                 executable="ros_rgbd",
                 output="screen",
                 parameters=[
-                    {"use_sim_time": LaunchConfiguration("offline")},
+                    {
+                        "use_sim_time": LaunchConfiguration("offline")
+                    },
                     {
                         "voc_file": LaunchConfiguration(
                             "voc_file",
@@ -72,44 +129,101 @@ def generate_launch_description():
                             ],
                         )
                     },
-                    {"roll": 0.0},
-                    {"yaw": 1.5697},
-                    {"pitch": -1.5697},
-                    {"frame_map": "map"},
-                    {"frame_world": "world"},
-                    {"frame_camera": "camera"},
-                    {"enable_pangolin": False},
-                    {"static_transform": True},
-                    {"colored_pointcloud": False},
-                    {"publish_pointclouds": True},
+                    {
+                        "roll": 1.5707963268
+                    },
+                    {
+                        "pitch": 0.0
+                    },
+                    {
+                        "yaw": 0.0
+                    },
+                    {
+                        "frame_map": "map"
+                    },
+                    {
+                        "frame_world": "world"
+                    },
+                    {
+                        "frame_camera": "camera"
+                    },
+                    {
+                        "enable_pangolin": False
+                    },
+                    {
+                        "static_transform": True
+                    },
+                    {
+                        "colored_pointcloud": False
+                    },
+                    {
+                        "publish_pointclouds": True
+                    },
                 ],
                 remappings=[
-                    ("/camera/rgb/image_raw", LaunchConfiguration("rgb_image_topic")),
+                    (
+                        "/camera/rgb/image_raw",
+                        LaunchConfiguration("rgb_image_topic")
+                    ),
                     (
                         "/camera/depth_registered/image_raw",
                         LaunchConfiguration("depth_image_topic"),
                     ),
                 ],
             ),
+
+            # ---------------------------------------------------------------- #
             # Static Transforms
+            # ---------------------------------------------------------------- #
+
             Node(
                 package="tf2_ros",
-                name="map_to_map_elevated", # For Voxblox Skeleton
+                name="map_to_map_elevated",
                 executable="static_transform_publisher",
-                arguments=["0", "0", "0", "0", "0", "0", "map", "map_elevated"],
+                arguments=[
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "map",
+                    "map_elevated"
+                ],
             ),
+
             Node(
                 package="tf2_ros",
                 executable="static_transform_publisher",
                 name="bc_to_se",
-                arguments=["0", "-3", "0", "0", "0", "0", "build_comp", "struc_elem"],
+                arguments=[
+                    "0",
+                    "-3",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "build_comp",
+                    "struc_elem"
+                ],
             ),
+
             Node(
                 package="tf2_ros",
                 executable="static_transform_publisher",
                 name="world_to_bc",
-                arguments=["0", "0.5", "0", "0", "0", "0", "world", "build_comp"],
+                arguments=[
+                    "0",
+                    "0.5",
+                    "0",
+                    "0",
+                    "0",
+                    "0",
+                    "world",
+                    "build_comp"
+                ],
             ),
+
             Node(
                 package="tf2_ros",
                 executable="static_transform_publisher",
@@ -122,11 +236,15 @@ def generate_launch_description():
                     "0",
                     "0",
                     "camera",
-                    "d400_color",
+                    "camera_color_optical_frame",
                     # RealSense: camera_color_optical_frame, OpenLoris: d400_color
                 ],
             ),
+
+            # ---------------------------------------------------------------- #
             # RViz
+            # ---------------------------------------------------------------- #
+
             Node(
                 condition=IfCondition(LaunchConfiguration("launch_rviz")),
                 package="rviz2",
@@ -139,9 +257,18 @@ def generate_launch_description():
                         "/config/Visualization/vsgraphs_rgbd.rviz",
                     ],
                 ],
+                parameters=[
+                    {
+                        "use_sim_time": LaunchConfiguration("offline")
+                    }
+                ],
                 output="screen",
             ),
+
+            # ---------------------------------------------------------------- #
             # Nodelete
+            # ---------------------------------------------------------------- #
+
             ComposableNodeContainer(
                 name="depth_image_proc_container",
                 package="rclcpp_components",
@@ -170,6 +297,7 @@ def generate_launch_description():
                     ),
                 ],
             ),
+
             # Semantic Scene Segmenter Node (based on semantic_scene_segmenter argument)
             Node(
                 condition=IfCondition(
@@ -182,8 +310,15 @@ def generate_launch_description():
                 executable="segmenter_yoso.py",
                 output="screen",
                 parameters=[
-                    {"visualize": LaunchConfiguration("visualize_segmented_scene")}
+                    {
+                        "use_sim_time": LaunchConfiguration("offline")
+                    },
+                    {
+                        "visualize": LaunchConfiguration(
+                            "visualize_segmented_scene")
+                    }
                 ],
+
                 arguments=[
                     "--ros-args",
                     "--params-file",
@@ -193,10 +328,14 @@ def generate_launch_description():
                     ],
                 ],
             ),
+
             Node(
                 condition=IfCondition(
                     EqualsSubstitution(
-                        LaunchConfiguration("semantic_scene_segmenter"), "pfcn"
+                        LaunchConfiguration(
+                            "semantic_scene_segmenter"
+                        ),
+                        "pfcn"
                     )
                 ),
                 name="segmenter_ros",
@@ -204,7 +343,10 @@ def generate_launch_description():
                 executable="segmenter_pFCN.py",
                 output="screen",
                 parameters=[
-                    {"visualize": LaunchConfiguration("visualize_segmented_scene")}
+                    {
+                        "visualize": LaunchConfiguration(
+                            "visualize_segmented_scene")
+                    }
                 ],
                 arguments=[
                     "--ros-args",
@@ -215,6 +357,37 @@ def generate_launch_description():
                     ],
                 ],
             ),
+
+            Node(
+                condition=IfCondition(
+                    EqualsSubstitution(
+                        LaunchConfiguration(
+                            "semantic_scene_segmenter"
+                        ),
+                        "segformer"
+                    )
+                ),
+                name="segmenter_ros",
+                package="segmenter_ros",
+                executable="segmenter_segformer.py",
+                output="screen",
+                parameters=[
+                    {
+                        "visualize": LaunchConfiguration(
+                            "visualize_segmented_scene"
+                        )
+                    }
+                ],
+                arguments=[
+                    "--ros-args",
+                    "--params-file",
+                    [
+                        get_package_share_directory("segmenter_ros"),
+                        "/config/cfg_segformer.yaml",
+                    ],
+                ],
+            ),
+
             # Structural Element Detectors
             # Node(
             #     name="situational_graphs_reasoning",

--- a/launch/rgbd.launch.py
+++ b/launch/rgbd.launch.py
@@ -53,7 +53,7 @@ def generate_launch_description():
                 choices=[
                     "yoso",
                     "pfcn",
-                    "segformer",
+                    "yolo26",
                     "off"
                 ],
             ),
@@ -292,7 +292,10 @@ def generate_launch_description():
                                 "depth_registered/image_rect",
                                 LaunchConfiguration("depth_image_topic"),
                             ),
-                            ("points", "/camera/depth/points"),
+                            (
+                                "points",
+                                "/camera/depth/points"
+                            ),
                         ],
                     ),
                 ],
@@ -302,7 +305,8 @@ def generate_launch_description():
             Node(
                 condition=IfCondition(
                     EqualsSubstitution(
-                        LaunchConfiguration("semantic_scene_segmenter"), "yoso"
+                        LaunchConfiguration("semantic_scene_segmenter"),
+                        "yoso"
                     )
                 ),
                 name="segmenter_ros",
@@ -345,7 +349,8 @@ def generate_launch_description():
                 parameters=[
                     {
                         "visualize": LaunchConfiguration(
-                            "visualize_segmented_scene")
+                            "visualize_segmented_scene"
+                        )
                     }
                 ],
                 arguments=[
@@ -364,12 +369,12 @@ def generate_launch_description():
                         LaunchConfiguration(
                             "semantic_scene_segmenter"
                         ),
-                        "segformer"
+                        "yolo26"
                     )
                 ),
                 name="segmenter_ros",
                 package="segmenter_ros",
-                executable="segmenter_segformer.py",
+                executable="segmenter_yolo26.py",
                 output="screen",
                 parameters=[
                     {
@@ -383,7 +388,7 @@ def generate_launch_description():
                     "--params-file",
                     [
                         get_package_share_directory("segmenter_ros"),
-                        "/config/cfg_segformer.yaml",
+                        "/config/cfg_yolo26.yaml",
                     ],
                 ],
             ),


### PR DESCRIPTION
## Description ##

Developed a simulation environment in the SGC which required VSGraph to work with gazebo. Hence, I added a config which can be used to work with gazebo simulated cameras and a ros bridge.

I also made the `ros_rgbd.launch.py` file more pythonic to make it easier to read and follow.

## Jira Link ##

- N/A

## Changes made ##

- [x] Added SMapper_Gazebo.yaml to interface with gaezbo cameras
- [x] Make `ros_rgbd.launch.py` file formatting follow pep standards and more pythonic

## Testing ##

- [x] Ran simple test within SgcOse environment
